### PR TITLE
Disable static build on Windows

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -14,8 +14,13 @@ share {
 	plugin Extract => 'tar.gz';
 
 	plugin 'Build::Autoconf';
+	my $enable_static = $^O ne 'MSWin32';
 	build [
-		'%{configure} --enable-static --enable-shared',
+		join(' ', (
+			'%{configure}',
+			$enable_static ? '--enable-static' : '--disable-static',
+			'--enable-shared'
+		)),
 		'%{make}',
 		'%{make} install',
 	];


### PR DESCRIPTION
This is so that the library is loaded by using the %PATH% to the DLL.
Otherwise the current linker settings for ZMQ::LibZMQ[34] prefer the
static library which then leads to linker errors of the form `undefined
reference to [libzmq symbol]`.


