### PR TITLE
Add option for choosing build configuration tool

### DIFF
--- a/.github/workflows/orbital-transfer.yml
+++ b/.github/workflows/orbital-transfer.yml
@@ -10,21 +10,30 @@ on:
 
 jobs:
   build:
-    name: "${{ matrix.os }} (alien_install_type: ${{ matrix.alien_install_type }}) ${{ matrix.joblabel }}"
+    name: "${{ matrix.os }} (alien_install_type: ${{ matrix.alien_install_type }}) (build_config_pref: ${{ matrix.build_config_pref }}) ${{ matrix.joblabel }}"
     runs-on: ${{ matrix.os }}
     env:
       ORBITAL_COVERAGE:    ${{ matrix.coverage }}
       ALIEN_INSTALL_TYPE:  ${{ matrix.alien_install_type }}
+      ALIEN_ZMQ_LATEST_BUILD_CONFIG: ${{ matrix.build_config_pref }}
     strategy:
       fail-fast: true
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         coverage: ['']
         alien_install_type: [ 'share', 'system' ]
+        build_config_pref: ['']
         include:
           - os: 'ubuntu-latest'
             coverage: coveralls
             joblabel: '(Coverage)'
+          - os: 'ubuntu-latest'
+            alien_install_type: 'share'
+            build_config_pref: 'autoconf'
+          - os: 'ubuntu-latest'
+            alien_install_type: 'share'
+            build_config_pref: 'cmake'
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/strawberry.yml
+++ b/.github/workflows/strawberry.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Strawberry Perl
 
 on:
   push:
@@ -11,10 +11,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       AUTHOR_TESTING: 1
+      ALIEN_ZMQ_LATEST_BUILD_CONFIG: ${{ matrix.build_config_pref }}
     strategy:
       matrix:
         os: ['windows-latest']
-    name: Strawberry Perl on ${{ matrix.os }}
+        build_config_pref: ['autoconf', 'cmake', '']
+    name: "Strawberry Perl on ${{ matrix.os }} (build_config_pref: ${{ matrix.build_config_pref }})"
 
     steps:
       - uses: actions/checkout@v2

--- a/alienfile
+++ b/alienfile
@@ -1,29 +1,37 @@
 use alienfile;
 
+use constant {
+	BUILD_CONF_PREF_AUTOCONF => 'autoconf',
+	BUILD_CONF_PREF_CMAKE => 'cmake',
+};
+
 plugin 'PkgConfig' => 'libzmq';
 
 # http://zeromq.org/
 share {
-	# $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} = (cmake|autoconf)
-	my $has_build_conf_pref = exists $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG};
-	my $prefer_cmake =
-		(
-			$has_build_conf_pref
-			&& $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} eq 'cmake';
-		)
-		|| 0;
+	my $default_build_conf_pref = BUILD_CONF_PREF_AUTOCONF;
+	my $build_conf_pref =
+		exists $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} && $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG}
+		? $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG}
+		: $default_build_conf_pref;
+
+	# $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} = (autoconf|cmake)
+	my $build_conf_re_alt = join "|", (BUILD_CONF_PREF_AUTOCONF, BUILD_CONF_PREF_CMAKE);
+	my $build_conf_re = qr/^($build_conf_re_alt)$/;
+	die <<EOF unless $build_conf_pref =~ $build_conf_re;
+Unknown ALIEN_ZMQ_LATEST_BUILD_CONFIG = '$build_conf_pref'. Must
+be '@{[ BUILD_CONF_PREF_AUTOCONF ]}' or '@{[ BUILD_CONF_PREF_CMAKE ]}'.
+EOF
+
 	my $make = '%{make}';
-	if( $prefer_cmake ) {
-		# use cmake
-		requires 'Alien::cmake3';
-	} else {
-		# use autoconf
+	if( $build_conf_pref eq BUILD_CONF_PREF_AUTOCONF ) {
 		if( $^O eq 'freebsd' ) {
 			requires 'Alien::gmake' => 0.14;
 			$make = '%{gmake}';
 		}
+	} elsif( $build_conf_pref eq BUILD_CONF_PREF_CMAKE ) {
+		requires 'Alien::cmake3';
 	}
-
 
 	plugin Download => (
 		url => 'https://github.com/zeromq/libzmq/releases',
@@ -34,20 +42,7 @@ share {
 
 	my $enable_static = $^O ne 'MSWin32';
 	my $enable_tests = 0;
-	if( $prefer_cmake ) {
-		plugin 'Build::CMake';
-		build [
-			[ '%{cmake}', -G => '%{cmake_generator}',
-				'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
-				"-DBUILD_STATIC=@{[ $enable_static ? 'ON' : 'OFF' ]}",
-				"-DZMQ_BUILD_TESTS=@{[ $enable_tests ? 'ON' : 'OFF' ]}",
-				qw(-S .),
-				qw(-B build),
-			],
-			[ $make, qw( -C build ) ],
-			[ $make, qw( -C build ), 'install' ],
-		];
-	} else {
+	if( $build_conf_pref eq BUILD_CONF_PREF_AUTOCONF ) {
 		plugin 'Build::Autoconf';
 		my $should_stub_tests = $^O eq 'MSWin32';
 		my @make_stub_tests = $should_stub_tests
@@ -61,6 +56,19 @@ share {
 			),
 			[ $make, @make_stub_tests ],
 			[ $make, 'install', @make_stub_tests ],
+		];
+	} elsif( $build_conf_pref eq BUILD_CONF_PREF_CMAKE ) {
+		plugin 'Build::CMake';
+		build [
+			[ '%{cmake}', -G => '%{cmake_generator}',
+				'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
+				"-DBUILD_STATIC=@{[ $enable_static ? 'ON' : 'OFF' ]}",
+				"-DZMQ_BUILD_TESTS=@{[ $enable_tests ? 'ON' : 'OFF' ]}",
+				qw(-S .),
+				qw(-B build),
+			],
+			[ $make, qw( -C build ) ],
+			[ $make, qw( -C build ), 'install' ],
 		];
 	}
 

--- a/alienfile
+++ b/alienfile
@@ -73,6 +73,10 @@ EOF
 					? ( '-DPKG_CONFIG_EXECUTABLE=' . File::Which::which('pkg-config'), )
 					: ()
 				),
+				( meta->prop->{platform}->{system_type} eq 'windows-mingw'
+				? ( '-DZMQ_HAVE_IPC=OFF' )
+				: ()
+				),
 				qw(-S .),
 				qw(-B build),
 			],

--- a/alienfile
+++ b/alienfile
@@ -11,7 +11,10 @@ plugin 'PkgConfig' => 'libzmq';
 share {
 	requires 'File::Which';
 
-	my $default_build_conf_pref = BUILD_CONF_PREF_AUTOCONF;
+	my $default_build_conf_pref =
+		$^O ne 'MSWin32'
+		? BUILD_CONF_PREF_AUTOCONF
+		: BUILD_CONF_PREF_CMAKE;
 	my $build_conf_pref =
 		exists $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} && $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG}
 		? $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG}

--- a/alienfile
+++ b/alienfile
@@ -4,7 +4,14 @@ plugin 'PkgConfig' => 'libzmq';
 
 # http://zeromq.org/
 share {
-	my $prefer_cmake = 0;
+	# $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} = (cmake|autoconf)
+	my $has_build_conf_pref = exists $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG};
+	my $prefer_cmake =
+		(
+			$has_build_conf_pref
+			&& $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} eq 'cmake';
+		)
+		|| 0;
 	my $make = '%{make}';
 	if( $prefer_cmake ) {
 		# use cmake

--- a/alienfile
+++ b/alienfile
@@ -9,6 +9,8 @@ plugin 'PkgConfig' => 'libzmq';
 
 # http://zeromq.org/
 share {
+	requires 'File::Which';
+
 	my $default_build_conf_pref = BUILD_CONF_PREF_AUTOCONF;
 	my $build_conf_pref =
 		exists $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG} && $ENV{ALIEN_ZMQ_LATEST_BUILD_CONFIG}
@@ -64,6 +66,10 @@ EOF
 				'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
 				"-DBUILD_STATIC=@{[ $enable_static ? 'ON' : 'OFF' ]}",
 				"-DZMQ_BUILD_TESTS=@{[ $enable_tests ? 'ON' : 'OFF' ]}",
+				( $^O eq 'MSWin32'
+					? ( '-DPKG_CONFIG_EXECUTABLE=' . File::Which::which('pkg-config'), )
+					: ()
+				),
 				qw(-S .),
 				qw(-B build),
 			],


### PR DESCRIPTION
- Allow for setting build config to cmake using env var
- More work on setting the build config preference
- GHA: test both build configs
- Help find pkg-config on MSWin32
- Prefer 'cmake' on Windows and 'autoconf' elsewhere

Fixes <https://github.com/zmughal-CPAN/p5-Alien-ZMQ-latest/issues/10>.
