### PR TITLE
Set make for autoconf build

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -49,7 +49,8 @@ EOF
 	my $enable_tests = 0;
 	if( $build_conf_pref eq BUILD_CONF_PREF_AUTOCONF ) {
 		plugin 'Build::Autoconf';
-		my $should_stub_tests = $^O eq 'MSWin32';
+		# OpenBSD / FreeBSD fixed in <https://github.com/zeromq/libzmq/pull/4174>.
+		my $should_stub_tests = $^O eq 'MSWin32' || $^O =~ /^(freebsd|openbsd)$/;
 		my @make_stub_tests = $should_stub_tests
 			? ( "noinst_LIBRARIES=" )
 			: ();

--- a/alienfile
+++ b/alienfile
@@ -30,7 +30,7 @@ EOF
 
 	my $make = '%{make}';
 	if( $build_conf_pref eq BUILD_CONF_PREF_AUTOCONF ) {
-		if( $^O eq 'freebsd' ) {
+		if( $^O eq 'freebsd' || $^O eq 'solaris' ) {
 			requires 'Alien::gmake' => 0.14;
 			$make = '%{gmake}';
 		}

--- a/alienfile
+++ b/alienfile
@@ -58,6 +58,7 @@ EOF
 				'%{configure}',
 				( $enable_static ? '--enable-static' : '--disable-static' ),
 				'--enable-shared',
+				"MAKE=$make",
 			),
 			[ $make, @make_stub_tests ],
 			[ $make, 'install', @make_stub_tests ],

--- a/maint/devops.yml
+++ b/maint/devops.yml
@@ -4,11 +4,14 @@ native:
     packages:
       - libzmq3-dev
       - cmake
+      - make
   macos-homebrew:
     packages:
       - zmq
       - cmake
+      - make
   msys2-mingw64:
     packages:
       - mingw-w64-x86_64-zeromq
       - mingw-w64-x86_64-cmake
+      - mingw-w64-x86_64-make


### PR DESCRIPTION
- Specify MAKE to autoconf
- Skip build of tests on OpenBSD / FreeBSD
- Require Alien::gmake on FreeBSD and Solaris.
