### PR TITLE
Use Download::GitHub

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+   - Change from regular Download to Download::GitHub.
 0.007 2022-02-12 11:55:08-0500
 
   Build changes

--- a/alienfile
+++ b/alienfile
@@ -38,9 +38,16 @@ EOF
 		requires 'Alien::cmake3';
 	}
 
-	plugin Download => (
-		url => 'https://github.com/zeromq/libzmq/releases',
-		version => qr/zeromq-([\d\.]+)\.tar\.gz/,
+	my $zeromq_qr = qr/zeromq-([\d\.]+)\.tar\.gz/;
+	plugin 'Prefer::SortVersions' => (
+		filter => $zeromq_qr,
+	);
+
+	plugin 'Download::GitHub' => (
+		github_user => 'zeromq',
+		github_repo => 'libzmq',
+		include_assets => $zeromq_qr,
+		version => $zeromq_qr,
 	);
 
 	plugin Extract => 'tar.gz';

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,8 @@ version = 0.007
 
 [AlienBuild]
 ; authordep Alien::Build::Plugin::Gather::Dino
+; authordep Alien::Build::Plugin::Download::GitHub
 
 [Prereqs / ConfigureRequires]
 Alien::Build::Plugin::Gather::Dino = 0
+Alien::Build::Plugin::Download::GitHub = 0


### PR DESCRIPTION
This is because all of the assets are no longer accessible directly
through the HTML releases page without JavaScript.
