### PR TITLE
Set CMAKE_MAKE_PROGRAM

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -74,6 +74,7 @@ EOF
 		plugin 'Build::CMake';
 		build [
 			[ '%{cmake}', -G => '%{cmake_generator}',
+				'-DCMAKE_MAKE_PROGRAM:PATH=%{make}',
 				'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
 				"-DBUILD_STATIC=@{[ $enable_static ? 'ON' : 'OFF' ]}",
 				"-DZMQ_BUILD_TESTS=@{[ $enable_tests ? 'ON' : 'OFF' ]}",


### PR DESCRIPTION
To avoid error:

> CMake Error: CMake was unable to find a build program corresponding to "MinGW Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
> CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
> CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
> -- Configuring incomplete, errors occurred!

Fixes <https://github.com/zmughal-CPAN/p5-Alien-ZMQ-latest/issues/14>.
