### PR TITLE
Apply build patches 2023-07

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch text eol=lf

--- a/.github/workflows/orbital-transfer.yml
+++ b/.github/workflows/orbital-transfer.yml
@@ -36,10 +36,10 @@ jobs:
             build_config_pref: 'cmake'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache Orbital
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-orbital
         with:

--- a/.github/workflows/strawberry.yml
+++ b/.github/workflows/strawberry.yml
@@ -13,6 +13,7 @@ jobs:
       AUTHOR_TESTING: 1
       ALIEN_ZMQ_LATEST_BUILD_CONFIG: ${{ matrix.build_config_pref }}
     strategy:
+      fail-fast: false
       matrix:
         os: ['windows-latest']
         build_config_pref: ['autoconf', 'cmake', '']

--- a/.github/workflows/strawberry.yml
+++ b/.github/workflows/strawberry.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Strawberry Perl on ${{ matrix.os }} (build_config_pref: ${{ matrix.build_config_pref }})"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up perl
         uses: shogo82148/actions-setup-perl@v1
         with:

--- a/.github/workflows/strawberry.yml
+++ b/.github/workflows/strawberry.yml
@@ -17,7 +17,10 @@ jobs:
       matrix:
         os: ['windows-latest']
         build_config_pref: ['autoconf', 'cmake', '']
-    name: "Strawberry Perl on ${{ matrix.os }} (build_config_pref: ${{ matrix.build_config_pref }})"
+        perl: ['5']
+        include:
+          - { os: 'windows-latest', perl: "5.32", build_config_pref: '' }
+    name: "Strawberry Perl ${{ matrix.perl }} on ${{ matrix.os }} (build_config_pref: ${{ matrix.build_config_pref }})"
 
     steps:
       - uses: actions/checkout@v3
@@ -25,6 +28,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with:
           distribution: 'strawberry'
+          perl-version: ${{ matrix.perl }}
       - run: perl -V
       - name: Install author deps
         run: |

--- a/alienfile
+++ b/alienfile
@@ -82,7 +82,7 @@ EOF
 					? ( '-DPKG_CONFIG_EXECUTABLE=' . File::Which::which('pkg-config'), )
 					: ()
 				),
-				( meta->prop->{platform}->{system_type} eq 'windows-mingw'
+				( meta->prop->{platform}->{system_type} =~ /^windows-(mingw|strawberry)$/
 				? ( '-DZMQ_HAVE_IPC=OFF' )
 				: ()
 				),

--- a/alienfile
+++ b/alienfile
@@ -53,7 +53,7 @@ EOF
 	plugin Extract => 'tar.gz';
 
 	# Patches on top of libzmq 4.3.4.
-	my @patch_commands = map '%{patch} -p1 < %{.install.patch}/' . $_, (
+	my @patch_commands = map '%{patch} -d src -p2 < %{.install.patch}/' . $_, (
 		'4213.patch',
 		'4480.patch',
 		'4494.patch',

--- a/alienfile
+++ b/alienfile
@@ -52,6 +52,14 @@ EOF
 
 	plugin Extract => 'tar.gz';
 
+	# Patches on top of libzmq 4.3.4.
+	my @patch_commands = map '%{patch} -p1 < %{.install.patch}/' . $_, (
+		'4213.patch',
+		'4480.patch',
+		'4494.patch',
+		'4507.patch',
+	);
+
 	my $enable_static = $^O ne 'MSWin32';
 	my $enable_tests = 0;
 	if( $build_conf_pref eq BUILD_CONF_PREF_AUTOCONF ) {
@@ -61,6 +69,7 @@ EOF
 			? ( "noinst_LIBRARIES=" )
 			: ();
 		build [
+			@patch_commands,
 			join(' ',
 				'%{configure}',
 				( $enable_static ? '--enable-static' : '--disable-static' ),
@@ -73,6 +82,7 @@ EOF
 	} elsif( $build_conf_pref eq BUILD_CONF_PREF_CMAKE ) {
 		plugin 'Build::CMake';
 		build [
+			@patch_commands,
 			[ '%{cmake}', -G => '%{cmake_generator}',
 				'-DCMAKE_MAKE_PROGRAM:PATH=%{make}',
 				'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',

--- a/maint/patch-list
+++ b/maint/patch-list
@@ -1,0 +1,4 @@
+https://github.com/zeromq/libzmq/pull/4213.patch?full_index=1
+https://github.com/zeromq/libzmq/pull/4480.patch?full_index=1
+https://github.com/zeromq/libzmq/pull/4494.patch?full_index=1
+https://github.com/zeromq/libzmq/pull/4507.patch?full_index=1

--- a/maint/patches-fetch.sh
+++ b/maint/patches-fetch.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Requires:
+#
+#   pkg:deb/debian/wget         (wget)
+#   pkg:deb/debian/patchutils   (filterdiff)
+#   pkg:deb/debian/moreutils    (sponge)
+#   pkg:cpan/dist/File-Rename   (rename)
+
+CURDIR=`dirname "$0"`
+
+set -eu
+cd $CURDIR
+PATCHES_DIR=../patch
+mkdir -p $PATCHES_DIR
+wget -P $PATCHES_DIR -ci patch-list
+rename -f 's/\Q?full_index=1\E//' $PATCHES_DIR/*.patch*
+filterdiff -p1 -x 'tests/*' $PATCHES_DIR/4494.patch | sponge $PATCHES_DIR/4494.patch
+
+filterdiff -p1 -x 'RELICENSE/*' $PATCHES_DIR/4507.patch \
+	| perl -0777 -pE 'my $REMOVE = <<EOF;
+diff --git a/RELICENSE/daira.md b/RELICENSE/daira.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..cc841a83fca614f2eccd0aebffe448caa991af81
+EOF
+s/@{[ quotemeta($REMOVE) ]}//s' \
+	| sponge $PATCHES_DIR/4507.patch

--- a/patch/4213.patch
+++ b/patch/4213.patch
@@ -1,0 +1,42 @@
+From 92b2c38a2c51a1942a380c7ee08147f7b1ca6845 Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <bluca@debian.org>
+Date: Sun, 13 Jun 2021 16:21:07 +0100
+Subject: [PATCH] Problem: build with curve fails on GCC 11
+
+Solution: ignore false positives due to compiler bug:
+
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578
+
+Fixes https://github.com/zeromq/libzmq/issues/4206
+---
+ src/curve_client_tools.hpp | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/curve_client_tools.hpp b/src/curve_client_tools.hpp
+index 3c098ba937e6f1010df97f46dfd9fe01cb62d7ed..7e0d25b3a413b7ff8a0e1d0f12fa14a3d8b6ba14 100644
+--- a/src/curve_client_tools.hpp
++++ b/src/curve_client_tools.hpp
+@@ -180,6 +180,12 @@ struct curve_client_tools_t
+         //  Create Box [C + vouch + metadata](C'->S')
+         std::fill (initiate_plaintext.begin (),
+                    initiate_plaintext.begin () + crypto_box_ZEROBYTES, 0);
++
++        //  False positives due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578
++#if __GNUC__ >= 11
++#pragma GCC diagnostic ignored "-Warray-bounds"
++#pragma GCC diagnostic ignored "-Wstringop-overflow="
++#endif
+         memcpy (&initiate_plaintext[crypto_box_ZEROBYTES], public_key_, 32);
+         memcpy (&initiate_plaintext[crypto_box_ZEROBYTES + 32], vouch_nonce + 8,
+                 16);
+@@ -189,6 +195,10 @@ struct curve_client_tools_t
+             memcpy (&initiate_plaintext[crypto_box_ZEROBYTES + 48 + 80],
+                     metadata_plaintext_, metadata_length_);
+         }
++#if __GNUC__ >= 11
++#pragma GCC diagnostic pop
++#pragma GCC diagnostic pop
++#endif
+ 
+         memcpy (initiate_nonce, "CurveZMQINITIATE", 16);
+         put_uint64 (initiate_nonce + 16, cn_nonce_);

--- a/patch/4480.patch
+++ b/patch/4480.patch
@@ -1,0 +1,58 @@
+From 438d5d88392baffa6c2c5e0737d9de19d6686f0d Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Tue, 20 Dec 2022 21:45:16 +0000
+Subject: [PATCH] src/secure_allocator.hpp: define missing 'rebind' type
+
+`gcc-13` added an assert to standard headers to make sure custom
+allocators have intended implementation of rebind type instead
+of inherited rebind. gcc change:
+    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=64c986b49558a7
+
+Without the fix build fails on this week's `gcc-13` as:
+
+    [ 92%] Building CXX object tests/CMakeFiles/test_security_curve.dir/test_security_curve.cpp.o
+    In file included from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:34,
+                     from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_uninitialized.h:64,
+                     from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/memory:69,
+                     from tests/../src/secure_allocator.hpp:42,
+                     from tests/../src/curve_client_tools.hpp:49,
+                     from tests/test_security_curve.cpp:53:
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h: In instantiation of 'struct std::__allocator_traits_base::__rebind<zmq::secure_allocator_t<unsigned char>, unsigned char, void>':
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:94:11:   required by substitution of 'template<class _Alloc, class _Up> using std::__alloc_rebind = typename std::__allocator_traits_base::__rebind<_Alloc, _Up>::type [with _Alloc = zmq::secure_allocator_t<unsigned char>; _Up = unsigned char]'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:228:8:   required by substitution of 'template<class _Alloc> template<class _Tp> using std::allocator_traits< <template-parameter-1-1> >::rebind_alloc = std::__alloc_rebind<_Alloc, _Tp> [with _Tp = unsigned char; _Alloc = zmq::secure_allocator_t<unsigned char>]'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:126:65:   required from 'struct __gnu_cxx::__alloc_traits<zmq::secure_allocator_t<unsigned char>, unsigned char>::rebind<unsigned char>'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:88:21:   required from 'struct std::_Vector_base<unsigned char, zmq::secure_allocator_t<unsigned char> >'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:423:11:   required from 'class std::vector<unsigned char, zmq::secure_allocator_t<unsigned char> >'
+    tests/../src/curve_client_tools.hpp:64:76:   required from here
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:70:31: error: static assertion failed: allocator_traits<A>::rebind_alloc<A::value_type> must be A
+       70 |                         _Tp>::value,
+          |                               ^~~~~
+
+The change adds trivial `rebind` definition with expected return type
+and satisfies conversion requirements.
+---
+ src/secure_allocator.hpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/secure_allocator.hpp b/src/secure_allocator.hpp
+index e0871dcc990eeb93ddaff5d9cc38c8c48dfcba60..5e97368911d2436b290b66d0d277f3435c49ba96 100644
+--- a/src/secure_allocator.hpp
++++ b/src/secure_allocator.hpp
+@@ -99,6 +99,17 @@ bool operator!= (const secure_allocator_t<T> &, const secure_allocator_t<U> &)
+ #else
+ template <typename T> struct secure_allocator_t : std::allocator<T>
+ {
++    secure_allocator_t () ZMQ_DEFAULT;
++
++    template <class U>
++    secure_allocator_t (const secure_allocator_t<U> &) ZMQ_NOEXCEPT
++    {
++    }
++
++    template <class U> struct rebind
++    {
++        typedef secure_allocator_t<U> other;
++    };
+ };
+ #endif
+ }

--- a/patch/4494.patch
+++ b/patch/4494.patch
@@ -1,0 +1,48 @@
+From f7df6c8599835d6022335d63f37e291514d9a6f4 Mon Sep 17 00:00:00 2001
+From: Arnaud Loonstra <arnaud@sphaero.org>
+Date: Tue, 24 Jan 2023 12:54:48 +0100
+Subject: [PATCH] deprecate sprint and replace with snprintf
+
+---
+ src/tcp_address.cpp              |  3 ++-
+ src/udp_engine.cpp               |  4 ++--
+ tests/test_inproc_connect.cpp    |  4 ++--
+ tests/test_issue_566.cpp         |  2 +-
+ tests/test_proxy.cpp             | 12 ++++++++----
+ tests/test_reqrep_tcp.cpp        |  8 ++++++--
+ tests/test_setsockopt.cpp        |  2 +-
+ tests/test_stream_disconnect.cpp |  4 ++--
+ tests/test_unbind_wildcard.cpp   | 12 ++++++------
+ tests/test_ws_transport.cpp      |  3 ++-
+ tests/testutil.cpp               | 18 +++++++++---------
+ 11 files changed, 41 insertions(+), 31 deletions(-)
+
+diff --git a/src/tcp_address.cpp b/src/tcp_address.cpp
+index bdda66a2002340cedc359c1949a53b06a18a0961..46b4defc79fe7e4c6f2760f7fcb8af6b631b723f 100644
+--- a/src/tcp_address.cpp
++++ b/src/tcp_address.cpp
+@@ -129,7 +129,8 @@ static std::string make_address_string (const char *hbuf_,
+     pos += hbuf_len;
+     memcpy (pos, ipv6_suffix_, sizeof ipv6_suffix_ - 1);
+     pos += sizeof ipv6_suffix_ - 1;
+-    pos += sprintf (pos, "%d", ntohs (port_));
++    pos += snprintf (pos, max_port_str_length + 1 * sizeof (char), "%d",
++                     ntohs (port_));
+     return std::string (buf, pos - buf);
+ }
+ 
+diff --git a/src/udp_engine.cpp b/src/udp_engine.cpp
+index d09bfe166ec3b4d161b3bf4e0acb24f6c5aab090..47f1359e1bdab32d82a8a0f09e2f2669e98f5230 100644
+--- a/src/udp_engine.cpp
++++ b/src/udp_engine.cpp
+@@ -367,8 +367,8 @@ void zmq::udp_engine_t::sockaddr_to_msg (zmq::msg_t *msg_,
+     const char *const name = inet_ntoa (addr_->sin_addr);
+ 
+     char port[6];
+-    const int port_len =
+-      sprintf (port, "%d", static_cast<int> (ntohs (addr_->sin_port)));
++    const int port_len = snprintf (port, 6 * sizeof (char), "%d",
++                                   static_cast<int> (ntohs (addr_->sin_port)));
+     zmq_assert (port_len > 0);
+ 
+     const size_t name_len = strlen (name);

--- a/patch/4507.patch
+++ b/patch/4507.patch
@@ -1,0 +1,48 @@
+From 6dc559c0726c2d2d9a928bd8d1ed89773c0b47ea Mon Sep 17 00:00:00 2001
+From: Daira Hopwood <daira@jacaranda.org>
+Date: Wed, 1 Feb 2023 15:15:19 +0000
+Subject: [PATCH] #4494 added calls to snprintf, but did not take into account
+ that snprintf can truncate, and then return the number of characters that
+ would have been written without truncation.
+
+Signed-off-by: Daira Hopwood <daira@jacaranda.org>
+---
+ RELICENSE/daira.md  | 15 +++++++++++++++
+ src/tcp_address.cpp |  5 +++--
+ src/udp_engine.cpp  |  6 +++---
+ 3 files changed, 21 insertions(+), 5 deletions(-)
+ create mode 100644 RELICENSE/daira.md
+
+diff --git a/src/tcp_address.cpp b/src/tcp_address.cpp
+index 46b4defc79fe7e4c6f2760f7fcb8af6b631b723f..cd8016f643e656e5dddaabb80c66ba11537570c9 100644
+--- a/src/tcp_address.cpp
++++ b/src/tcp_address.cpp
+@@ -129,8 +129,9 @@ static std::string make_address_string (const char *hbuf_,
+     pos += hbuf_len;
+     memcpy (pos, ipv6_suffix_, sizeof ipv6_suffix_ - 1);
+     pos += sizeof ipv6_suffix_ - 1;
+-    pos += snprintf (pos, max_port_str_length + 1 * sizeof (char), "%d",
+-                     ntohs (port_));
++    int res = snprintf (pos, max_port_str_length + 1, "%d", ntohs (port_));
++    zmq_assert (res > 0 && res < (int) (max_port_str_length + 1));
++    pos += res;
+     return std::string (buf, pos - buf);
+ }
+ 
+diff --git a/src/udp_engine.cpp b/src/udp_engine.cpp
+index 47f1359e1bdab32d82a8a0f09e2f2669e98f5230..5ca03a425b5ced993cf05fc89dc82969bb40e518 100644
+--- a/src/udp_engine.cpp
++++ b/src/udp_engine.cpp
+@@ -367,9 +367,9 @@ void zmq::udp_engine_t::sockaddr_to_msg (zmq::msg_t *msg_,
+     const char *const name = inet_ntoa (addr_->sin_addr);
+ 
+     char port[6];
+-    const int port_len = snprintf (port, 6 * sizeof (char), "%d",
+-                                   static_cast<int> (ntohs (addr_->sin_port)));
+-    zmq_assert (port_len > 0);
++    const int port_len =
++      snprintf (port, 6, "%d", static_cast<int> (ntohs (addr_->sin_port)));
++    zmq_assert (port_len > 0 && port_len < 6);
+ 
+     const size_t name_len = strlen (name);
+     const int size = static_cast<int> (name_len) + 1 /* colon */


### PR DESCRIPTION
- Disable `ZMQ_HAVE_IPC` for windows-strawberry
- Add patches to libzmq 4.3.4
- CI: Update GHA actions/*
- Clean up patches
- Test with older Strawberry Perl
- Make sure `*.patch` uses LF for eol

Connects with <https://github.com/zeromq/perlzmq/pull/52>.
